### PR TITLE
#138 fix: Allow both empty string and None for empty cells

### DIFF
--- a/applications/portal/backend/api/resources/AntibodyResource.py
+++ b/applications/portal/backend/api/resources/AntibodyResource.py
@@ -214,7 +214,7 @@ class AntibodyResource(ModelResource):
         if field.attribute and (field.column_name in data):
             if is_fill:
                 # If we are only updating the filled columns and the column is empty we do nothing
-                if data[field.column_name] == '':
+                if data[field.column_name] == '' or data[field.column_name] is None:
                     return
                 if data[field.column_name] == REMOVE_KEYWORD:
                     data[field.column_name] = None


### PR DESCRIPTION
Fixes the bug reported [here](https://github.com/MetaCell/scicrunch-antibody-registry/issues/138#issuecomment-1466237176)

- Allows both empty string and None values for defining empty cells