### PR TITLE
fix: Fix conflicting model instructions

### DIFF
--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -263,7 +263,7 @@ class Antibody(models.Model):
     insert_time = models.DateTimeField(
         auto_now_add=True, db_index=True, null=True, blank=True)
     lastedit_time = models.DateTimeField(
-        auto_now=True, auto_now_add=True, db_index=True, blank=True)
+        auto_now=True, db_index=True, blank=True)
     curate_time = models.DateTimeField(db_index=True, null=True, blank=True)
     # whether the full link to the antibody is shown. If None, the vendor's default is used
     show_link = models.BooleanField(null=True, blank=True)


### PR DESCRIPTION
Fixes: 
> api.Antibody.lastedit_time: (fields.E160) The options auto_now, auto_now_add, and default are mutually exclusive. Only one of these options may be present.

auto_now:

This is primarily used for "last modified" timestamps.
Every time the object is saved, this field is set to the current date and time.
It sets the field's value to the current date & time every time the object's save() method is called.
As a result, you cannot manually set this field's value, even if you want to.

auto_now_add:

This is used for "creation" timestamps.
When the object is first created (and saved), this field is set to the current date and time.
After that, it will not change, even if you update the object.
This field's value is only set once: when the object is first created.