### PR TITLE
AREG-89 Improve performances of the import

### DIFF
--- a/applications/portal/backend/api/import_export/AntibodyResource.py
+++ b/applications/portal/backend/api/import_export/AntibodyResource.py
@@ -172,7 +172,7 @@ class AntibodyResource(ModelResource):
         super().after_import(dataset, result, using_transactions, dry_run, **kwargs)
         from multiprocessing.pool import ThreadPool
 
-        with ThreadPool() as pool:  # Set by default to the number of CPUs
+        with ThreadPool(processes=8) as pool:  # Set by default to the number of CPUs
             for result in pool.map(lambda instance: instance.save(update_search=False, from_import=True), self.instances):
                 ...
         refresh_search_view()

--- a/applications/portal/backend/api/import_export/AntibodyResource.py
+++ b/applications/portal/backend/api/import_export/AntibodyResource.py
@@ -163,7 +163,7 @@ class AntibodyResource(ModelResource):
                 # we don't have transactions and we want to do a dry_run
                 pass
             else:
-                self.instances.append(instance)
+                # self.instances.append(instance)
                 # instance.save(update_search=False, from_import=True)
                 instance.import_save()
         self.after_save_instance(instance, using_transactions, dry_run)

--- a/applications/portal/backend/api/import_export/AntibodyResource.py
+++ b/applications/portal/backend/api/import_export/AntibodyResource.py
@@ -38,7 +38,7 @@ class AntibodyIdentifier:
 class AntibodyInstanceLoaderClass(ModelInstanceLoader):
     def get_instance(self, q):
         instances = self.get_queryset().filter(q).order_by('insert_time')
-        return instances[0] if len(instances) > 0 else None
+        return instances.first()
 
 
 class AntibodyResource(ModelResource):
@@ -160,7 +160,7 @@ class AntibodyResource(ModelResource):
                 # we don't have transactions and we want to do a dry_run
                 pass
             else:
-                instance.save(update_search=False)
+                instance.save(update_search=False, from_import=True)
         self.after_save_instance(instance, using_transactions, dry_run)
 
     def after_import(self, dataset, result, using_transactions, dry_run, **kwargs):

--- a/applications/portal/backend/api/import_export/AntibodyResource.py
+++ b/applications/portal/backend/api/import_export/AntibodyResource.py
@@ -122,6 +122,9 @@ class AntibodyResource(ModelResource):
         ]
         self.request = request
 
+        self.instances = []
+
+
     class Meta:
         model = Antibody
         fields = (
@@ -160,11 +163,18 @@ class AntibodyResource(ModelResource):
                 # we don't have transactions and we want to do a dry_run
                 pass
             else:
-                instance.save(update_search=False, from_import=True)
+                self.instances.append(instance)
+                # instance.save(update_search=False, from_import=True)
+                # instance.save.__wrapped__(instance, update_search=False, from_import=True)
         self.after_save_instance(instance, using_transactions, dry_run)
 
     def after_import(self, dataset, result, using_transactions, dry_run, **kwargs):
         super().after_import(dataset, result, using_transactions, dry_run, **kwargs)
+        from multiprocessing.pool import ThreadPool
+
+        with ThreadPool() as pool:  # Set by default to the number of CPUs
+            for result in pool.map(lambda instance: instance.save(update_search=False, from_import=True), self.instances):
+                ...
         refresh_search_view()
 
     def get_or_init_instance(self, instance_loader, row):
@@ -274,9 +284,9 @@ class AntibodyResource(ModelResource):
             row['link'] = True
         if row.get('clonality', None):
             clonality = row['clonality'].lower()
-            
+
             row['clonality'] = clonality if clonality in CLONALITIES else None
-            
+
         if row.get('commercial_type', None):
             commercial_type = row['commercial_type'].lower()
             row['commercial_type'] = commercial_type if commercial_type in COMMERCIAL_TYPES else None

--- a/applications/portal/backend/api/import_export/AntibodyResource.py
+++ b/applications/portal/backend/api/import_export/AntibodyResource.py
@@ -164,17 +164,17 @@ class AntibodyResource(ModelResource):
                 pass
             else:
                 self.instances.append(instance)
-                # instance.save(update_search=False, from_import=True)
+                instance.save(update_search=False, from_import=True)
                 # instance.save.__wrapped__(instance, update_search=False, from_import=True)
         self.after_save_instance(instance, using_transactions, dry_run)
 
     def after_import(self, dataset, result, using_transactions, dry_run, **kwargs):
         super().after_import(dataset, result, using_transactions, dry_run, **kwargs)
-        from multiprocessing.pool import ThreadPool
+        # from multiprocessing.pool import ThreadPool
 
-        with ThreadPool(processes=8) as pool:  # Set by default to the number of CPUs
-            for result in pool.map(lambda instance: instance.save(update_search=False, from_import=True), self.instances):
-                ...
+        # with ThreadPool(processes=8) as pool:  # Set by default to the number of CPUs
+        #     for result in pool.map(lambda instance: instance.save(update_search=False, from_import=True), self.instances):
+        #       ...
         refresh_search_view()
 
     def get_or_init_instance(self, instance_loader, row):

--- a/applications/portal/backend/api/import_export/AntibodyResource.py
+++ b/applications/portal/backend/api/import_export/AntibodyResource.py
@@ -164,8 +164,8 @@ class AntibodyResource(ModelResource):
                 pass
             else:
                 self.instances.append(instance)
-                instance.save(update_search=False, from_import=True)
-                # instance.save.__wrapped__(instance, update_search=False, from_import=True)
+                # instance.save(update_search=False, from_import=True)
+                instance.import_save()
         self.after_save_instance(instance, using_transactions, dry_run)
 
     def after_import(self, dataset, result, using_transactions, dry_run, **kwargs):

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -274,10 +274,14 @@ class Antibody(models.Model):
 
     def import_save(self):
         first_save = self.ix is None
-        super().save()
         if first_save:
-            self._generate_automatic_attributes()
             super().save()
+            self._handle_duplicates()
+        if self.catalog_num:
+            self.catalog_num_search = catalog_number_chunked(self.catalog_num)
+        if not self.accession or not self.ab_id:
+            self._generate_automatic_attributes()
+        super().save()
 
     @transaction.atomic
     def save(self, *args, update_search=True, **kwargs):

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -272,6 +272,14 @@ class Antibody(models.Model):
     # whether the full link to the antibody is shown. If None, the vendor's default is used
     show_link = models.BooleanField(null=True, blank=True, db_index=True)
 
+    def import_save(self):
+        first_save = self.ix is None
+        self._handle_status_changes(first_save)
+        super().save()
+        if first_save:
+            self._generate_automatic_attributes()
+            super().save()
+
     @transaction.atomic
     def save(self, *args, update_search=True, from_import=False, **kwargs):
         first_save = self.ix is None

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -280,15 +280,9 @@ class Antibody(models.Model):
             super().save()
 
     @transaction.atomic
-    def save(self, *args, update_search=True, from_import=False, **kwargs):
+    def save(self, *args, update_search=True, **kwargs):
         first_save = self.ix is None
         self._handle_status_changes(first_save)
-        if from_import:
-            super().save(*args, **kwargs)
-            if first_save:
-                self._generate_automatic_attributes(*args, **kwargs)
-                super().save()
-            return
 
         # It's not an import that activated the save
         # We need to merge the data in a smart way

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -274,8 +274,8 @@ class Antibody(models.Model):
 
     def import_save(self):
         first_save = self.ix is None
-        self._generate_automatic_attributes(first_save)
         super().save()
+        self._generate_automatic_attributes(first_save)
         if first_save:
             super().save()
 

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -273,11 +273,17 @@ class Antibody(models.Model):
     show_link = models.BooleanField(null=True, blank=True, db_index=True)
 
     @transaction.atomic
-    def save(self, *args, update_search=True, **kwargs):
-
+    def save(self, *args, update_search=True, from_import=False, **kwargs):
         first_save = self.ix is None
         self._handle_status_changes(first_save)
+        if from_import:
+            if first_save:
+                self._generate_automatic_attributes(*args, **kwargs)
+            super().save(*args, **kwargs)
+            return
 
+        # It's not an import that activated the save
+        # We need to merge the data in a smart way
         old_instance = Antibody.objects.filter(pk=self.pk).first()
         old_species = self.species_from_raw(old_instance.target_species_raw) if old_instance else set()
 
@@ -304,7 +310,7 @@ class Antibody(models.Model):
             return self.target_species_raw != old_instance.target_species_raw
         return self.target_species_raw is not None
 
- 
+
     def delete(self, *args, **kwargs):
         super(Antibody, self).delete(*args, **kwargs)
         if self.status == STATUS.CURATED:
@@ -383,12 +389,12 @@ class Antibody(models.Model):
                     specie_name = specie_name.strip().lower()
                     specie, _ = Specie.objects.get_or_create(name=specie_name)
                     self.species.add(specie)
-        
+
         self._fill_target_species_raw_from_species()
 
-            
 
-            
+
+
 
     def _target_species_from_raw(self):
         species = []
@@ -452,11 +458,11 @@ class Antibody(models.Model):
                 self.add_vendor_domain(base_url, vendor)
         except Vendor.DoesNotExist:
             # Then, try to match by domain
-            
+
             vds = VendorDomain.objects.filter(base_url__iexact=base_url, status=STATUS.CURATED)
             if len(vds) == 0:
                 # If the domain is not matched, try to match by domain with and without www
-                
+
                 if "www." in base_url:
                     alt_base_url = base_url.replace("www.", "")
                 else:
@@ -475,7 +481,7 @@ class Antibody(models.Model):
                     if base_url:
                         self.add_vendor_domain(base_url, vendor)
                     return
-            
+
 
             # Vendor domain matched one way or the other, so associate to existing vendor
             if len(vds) > 1:

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -275,8 +275,8 @@ class Antibody(models.Model):
     def import_save(self):
         first_save = self.ix is None
         super().save()
-        self._generate_automatic_attributes(first_save)
         if first_save:
+            self._generate_automatic_attributes()
             super().save()
 
     @transaction.atomic

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -274,10 +274,9 @@ class Antibody(models.Model):
 
     def import_save(self):
         first_save = self.ix is None
-        self._handle_status_changes(first_save)
+        self._generate_automatic_attributes(first_save)
         super().save()
         if first_save:
-            self._generate_automatic_attributes()
             super().save()
 
     @transaction.atomic

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -277,9 +277,10 @@ class Antibody(models.Model):
         first_save = self.ix is None
         self._handle_status_changes(first_save)
         if from_import:
+            super().save(*args, **kwargs)
             if first_save:
                 self._generate_automatic_attributes(*args, **kwargs)
-            super().save(*args, **kwargs)
+                super().save()
             return
 
         # It's not an import that activated the save

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -335,7 +335,7 @@ class Antibody(models.Model):
         if not self.accession:
             self.accession = self.ab_id
         elif type(self.accession) is str:
-            self.accession = int(self.accession.replace('AB_', ''))
+            self.accession = int(float(self.accession.replace('AB_', '')))
         if self.status is None:
             self.status = STATUS.QUEUE
         if not self.uid:


### PR DESCRIPTION
The current CSV import of antibodies is slow, there is a couple of fixes made here:

1. the save is not making so much tests at the moment of saving
2. there is a threadpool for trying to save the instances in a parallel way, however the `@atomic` on the `save(...)` method of Antibody probably prevent the threadpool to work properly. I let it anyway, just in case. 

Here is the results I measured for 500 antibodies:

* 500 updates
  * current version: between 18 and 20s
  * this PR: between 10 and 12s
* 500 creates
  * current version: between 15 and 18s
  * this PR: between 9 and 11s

It's faster, but not drastically faster. 

Note 1: When using the threadpool, we cannot remove the `@atomic` on the `save(...)`
Note 2: Not using the threadpool and removing the `@atomic` implies also a little bit of perf improvement, but I'm not sure why the `@atomic` is here in the first place, and if we can safely remove it.