### PR TITLE
Feature/AREG-46 - Set antibodies "link" value in bulk import

### DIFF
--- a/applications/portal/backend/api/helpers/sentry.py
+++ b/applications/portal/backend/api/helpers/sentry.py
@@ -2,6 +2,7 @@ import cloudharness.sentry as sentry
 from cloudharness.applications import get_current_configuration
 from sentry_sdk.integrations.django import DjangoIntegration
 import re
+from cloudharness import log
 
 def init_sentry():
     try:

--- a/applications/portal/backend/api/import_export/AntibodyResource.py
+++ b/applications/portal/backend/api/import_export/AntibodyResource.py
@@ -51,7 +51,7 @@ class AntibodyResource(ModelResource):
     )
     catalog_num = Field(attribute='catalog_num', column_name='catalog_num')
     url = Field(attribute='url', column_name='url')
-    link = Field(column_name='link')
+    link = Field(column_name="link", attribute="show_link")
     target = Field(
         column_name='ab_target',
         attribute='ab_target'
@@ -123,7 +123,6 @@ class AntibodyResource(ModelResource):
         self.request = request
 
         self.instances = []
-
 
     class Meta:
         model = Antibody
@@ -280,8 +279,7 @@ class AntibodyResource(ModelResource):
 
         if row.get('link', None):
             row['link'] = 'y' in row['link'].lower()
-        else:
-            row['link'] = True
+
         if row.get('clonality', None):
             clonality = row['clonality'].lower()
 
@@ -309,3 +307,9 @@ class AntibodyResource(ModelResource):
                     data[field.column_name] = None
             # Otherwise we save the field
             field.save(obj, data, is_m2m, **kwargs)
+
+    # Change the link (boolean) to yes or no for the export
+    def dehydrate_link(self, obj):
+        if obj.show_link is None:
+            return ""
+        return "yes" if obj.show_link else "no"


### PR DESCRIPTION
Jira link - [AREG-46](https://metacell.atlassian.net/browse/AREG-46)

Changes:
- From the import - Add new antibodies and the link attribute - as yes/no. 
- From the import - Update the already present antibodies and it's link - yes/no.
- Also updates for the export - converting values from BOOLEAN (TRUE/FALSE) - to - yes/no.

- A behavior to note - If link is empty during the import - it is kept as it is - https://github.com/MetaCell/scicrunch-antibody-registry/blob/f38679cc661ce048de29244847dc6d4e68ebd320/applications/portal/backend/api/import_export/AntibodyResource.py#L305


Export sample


![image](https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/ee2f00df-b381-4b9e-836b-f416f61c344e)

Import  sample:
<img width="431" alt="image" src="https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/6f7e1d94-870e-4f18-b5f0-346cc20c3832">





Video demo:

https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/e9549246-0f89-46e4-a69f-4b8655d33caf






[AREG-46]: https://metacell.atlassian.net/browse/AREG-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ