### PR TITLE
#110 #113 - download cols fix + show all reset fix

### DIFF
--- a/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
+++ b/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
@@ -6,7 +6,8 @@ import {
   GridColDef,
   GridRenderCellParams,
   GridCsvExportOptions,
-  GridNoRowsOverlay
+  GridNoRowsOverlay,
+  GridColumnVisibilityModel
 } from "@mui/x-data-grid";
 import {
   Typography,
@@ -32,7 +33,7 @@ import {
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import TableHeader from "./HomeHeader";
 import { Antibody } from "../../rest";
-import { checkIfFilterSetExists, getProperCitation, getRandomId } from "../../utils/antibody";
+import { checkIfFilterSetExists, getColumnsToDisplay, getProperCitation, getRandomId } from "../../utils/antibody";
 import { UserContext } from "../../services/UserService";
 import ConnectAccount from "./ConnectAccount";
 import { ALLRESULTS, SEARCH_MODES, MYSUBMISSIONS, BLANK_FILTER_MODEL } from "../../constants/constants";
@@ -158,8 +159,8 @@ const RenderVendor = (props) => (
     className="col-vendor"
   >
     {props.row.url ? <Link className="link-vendor" bgcolor="primary.light" px={0.5} py={0.25} display="block" underline="none" target="_blank" href={props.row.url}>
-      {props.row.vendorName}
-    </Link> : props.row.vendorName}
+      {props.value}
+    </Link> : props.value}
   </Typography>
 )
 
@@ -447,14 +448,12 @@ const AntibodiesTable = (props) => {
       field: "abName",
       headerName: "Name",
       hide: true,
-      renderCell: RenderCellContent,
     },
     {
       ...columnsDefaultProps,
       field: "abId",
       headerName: "ID",
       hide: true,
-      renderCell: RenderCellContent,
     },
     {
       ...columnsDefaultProps,
@@ -481,12 +480,11 @@ const AntibodiesTable = (props) => {
     // },
     {
       ...columnsDefaultProps,
-      field: "species",
+      field: "targetSpecies",
       headerName: "Target species",
       valueGetter: getList,
       hide: true,
       sortable: false,
-      renderCell: RenderCellContent,
     },
     {
       ...columnsDefaultProps,
@@ -541,18 +539,16 @@ const AntibodiesTable = (props) => {
       field: "cloneId",
       headerName: "Clone ID",
       hide: true,
-      renderCell: RenderCellContent,
     },
     {
       ...columnsDefaultProps,
       field: "sourceOrganism",
       headerName: "Host organism",
       flex: 1.5,
-      renderCell: RenderCellContent,
     },
     {
       ...columnsDefaultProps,
-      field: "vendor",
+      field: "vendorName",
       headerName: "Vendor",
       flex: 1.5,
       renderCell: RenderVendor,
@@ -562,7 +558,6 @@ const AntibodiesTable = (props) => {
       ...columnsDefaultProps,
       field: "catalogNum",
       headerName: "Cat Num",
-      renderCell: RenderCellContent,
     },
     {
       ...columnsDefaultProps,
@@ -609,6 +604,8 @@ const AntibodiesTable = (props) => {
     },
   };
 
+  const [showColumns, setShowColumns] = useState<GridColumnVisibilityModel>(getColumnsToDisplay(columns));
+
   const NoRowsOverlay = () =>
     typeof activeSearch === "string" &&
     activeSearch !== "" &&
@@ -645,6 +642,8 @@ const AntibodiesTable = (props) => {
             onSortModelChange={(model) => addSortingColumn(model)}
             checkboxSelection
             disableSelectionOnClick
+              columnVisibilityModel={showColumns || {}}
+              onColumnVisibilityModelChange={(model) => setShowColumns(model)}
             getRowHeight={() => "auto"}
             loading={!searchedAntibodies || loader}
             onFilterModelChange={(model) => addNewFilterColumn(model)}

--- a/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
+++ b/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
@@ -642,8 +642,8 @@ const AntibodiesTable = (props) => {
             onSortModelChange={(model) => addSortingColumn(model)}
             checkboxSelection
             disableSelectionOnClick
-              columnVisibilityModel={showColumns || {}}
-              onColumnVisibilityModelChange={(model) => setShowColumns(model)}
+            columnVisibilityModel={showColumns || {}}
+            onColumnVisibilityModelChange={(model) => setShowColumns(model)}
             getRowHeight={() => "auto"}
             loading={!searchedAntibodies || loader}
             onFilterModelChange={(model) => addNewFilterColumn(model)}

--- a/applications/portal/frontend/src/utils/antibody.ts
+++ b/applications/portal/frontend/src/utils/antibody.ts
@@ -1,6 +1,7 @@
-import { GridFilterModel } from "@mui/x-data-grid";
+import { GridFilterModel, GridColumnVisibilityModel } from "@mui/x-data-grid";
 import { Antibody, SearchCriteriaOptions } from "../rest";
 import { modelType } from "../constants/constants";
+
 
 export function getProperCitation(a: Antibody) {
   if(!a) {return "ERROR";}
@@ -89,3 +90,13 @@ export function mapColumnToBackendModel(columnItems, modeltype) {
   });
   return newFilters;
 }
+
+
+export const getColumnsToDisplay = (columns) => {
+  let showcolList: GridColumnVisibilityModel = {};
+  columns.filter((column) => column?.hide === true).map((column) => {
+    showcolList[column.field] = false;
+  });
+  return showcolList;
+}
+


### PR DESCRIPTION
Changes:
- Added - Show visible columns property to data grid
- cleaned and removed unneccesary code
- Fix the vendor and target species - naming issue - for downloading the csv.

<br>
<hr>


Please check II and III points here - https://metacell.atlassian.net/browse/AREG-110?focusedCommentId=14075

I think they are already correct. The accessions reflect the values in the dev areg (from my testing). And status is supposed to show Accepted when - Curated. 

<img width="438" alt="image" src="https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/0b90fcf4-6903-4cbf-84f2-8625247487e3">

