### PR TITLE
Feature/areg-117 - When importing from csv, the new vendor type it defaults to "other" ignoring the antibody type

### DIFF
--- a/applications/portal/backend/api/import_export/AntibodyResource.py
+++ b/applications/portal/backend/api/import_export/AntibodyResource.py
@@ -43,12 +43,6 @@ class AntibodyInstanceLoaderClass(ModelInstanceLoader):
 
 class AntibodyResource(ModelResource):
     name = Field(attribute='ab_name', column_name='ab_name')
-    vendor = Field(
-        column_name='vendor',
-        attribute='vendor',
-        widget=ForeignKeyWidgetWithCreation(model=Vendor, field='name',
-                                            get_or_create=lambda **kwargs: get_or_create_vendor(**kwargs)[0])
-    )
     catalog_num = Field(attribute='catalog_num', column_name='catalog_num')
     url = Field(attribute='url', column_name='url')
     link = Field(column_name="link", attribute="show_link")
@@ -84,6 +78,14 @@ class AntibodyResource(ModelResource):
     disc_date = Field(attribute='disc_date', column_name='disc_date')
     commercial_type = Field(attribute='commercial_type',
                             column_name='commercial_type')
+    vendor = Field(
+        column_name='vendor',
+        attribute='vendor',
+        widget=ForeignKeyWidgetWithCreation(
+            model=Vendor, field='name', other_cols_map={'commercial_type': 'commercial_type'},
+            get_or_create=lambda **kwargs: get_or_create_vendor(**kwargs)[0]
+        )
+    )
     uniprot = Field(attribute='uniprot_id', column_name='uniprot_id')
     epitope = Field(attribute='epitope', column_name='epitope')
     cat_alt = Field(attribute='cat_alt', column_name='cat_alt')

--- a/applications/portal/backend/api/services/vendor_service.py
+++ b/applications/portal/backend/api/services/vendor_service.py
@@ -6,6 +6,7 @@ from api.utilities.exceptions import RequiredParameterMissing
 
 def get_or_create_vendor(**kwargs) -> Tuple:
     name = kwargs.get('name', None)
+    commercial_type = kwargs.get('commercial_type', None)
     if name is None:
         raise RequiredParameterMissing('name')
 
@@ -14,6 +15,9 @@ def get_or_create_vendor(**kwargs) -> Tuple:
         vendor = Vendor.objects.get(name=name)
     except Vendor.DoesNotExist:
         vendor = Vendor(**kwargs)
+        vendor.name = name
+        if commercial_type:
+            vendor.commercial_type = commercial_type
         vendor.save()
         new = True
     return vendor, new


### PR DESCRIPTION
Jira Link - https://metacell.atlassian.net/browse/AREG-117

Changes:
- Save Antibody Commercial type - into Vendor Commercial type - when new vendor comes up from - Importing Antibodies from CSV. 
- Earlier it saved "other" by default. Since that was the default for any Vendor's commercial type. Now it saves from the Antibodies commercial_type. 


Video demo

https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/74e060da-e154-49dd-b5c7-f432e218e405

