### PR TITLE
Feature/areg-116 -  antibody url BE and FE changes - only if permitted

### DIFF
--- a/applications/portal/backend/api/mappers/antibody_mapper.py
+++ b/applications/portal/backend/api/mappers/antibody_mapper.py
@@ -12,7 +12,7 @@ from api.utilities.exceptions import AntibodyDataException
 from cloudharness import log
 from openapi.models import Antibody as AntibodyDTO
 from openapi.models import AbstractAntibody as AbstractAntibodyDTO
-from .mapping_utils import dict_to_snake, dict_to_camel, to_snake
+from .mapping_utils import dict_to_snake, dict_to_camel, to_snake, get_url_if_permitted
 from ..services.gene_service import get_or_create_gene
 from ..services.specie_service import get_or_create_specie
 
@@ -128,6 +128,9 @@ class AntibodyMapper(IDAOMapper):
             ab.sourceOrganism = dao.source_organism.name
         if dao.species and not ab.targetSpecies:
             ab.targetSpecies = [s.name for s in dao.species.all()]
+        
+            
+        ab.url = get_url_if_permitted(dao)
 
         ab.showLink = dao.show_link if dao.show_link is not None else (dao.vendor and dao.vendor.show_link)
 

--- a/applications/portal/backend/api/mappers/mapping_utils.py
+++ b/applications/portal/backend/api/mappers/mapping_utils.py
@@ -1,5 +1,5 @@
 import re
-
+from api.services.user_service import get_current_user_id
 
 def to_snake(camel_str: str):
     return re.sub(r'(?<!^)(?=[A-Z])', '_', camel_str).lower()
@@ -56,3 +56,20 @@ if __name__ == '__main__':
         "uniprotId": "string",
         "vendorName": "string"
     })))
+
+
+def get_url_if_permitted(dao):
+    """
+        Get antibody URL only if permitted. RULES:
+        1. If user is creator of the antibody, return the URL.
+        2. Else return only if show_link is True.
+    """
+    try:
+        user_id = get_current_user_id()
+    except Exception as e:
+        return dao.url if dao.show_link else None
+    
+    if user_id == dao.uid:
+        return dao.url if dao.url else None
+    else:
+        return dao.url if dao.show_link else None

--- a/applications/portal/backend/api/repositories/search_repository.py
+++ b/applications/portal/backend/api/repositories/search_repository.py
@@ -127,7 +127,7 @@ def fts_and_filter_search(page: int = 0, size: int = 10, search: str = '', filte
         base_query
         .filter(convert_filters_to_q(filters))
         .select_related("vendor").prefetch_related("species")
-    )
+    ).distinct()
 
     antibodies_count = filtered_antibodies.count()
     if antibodies_count == 0:

--- a/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
+++ b/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
@@ -125,17 +125,6 @@ const getValueOrEmpty = (props: ValueProps) => {
 };
 
 const RenderCellContent = (props: GridRenderCellParams<String>) => {
-  const cellMapper = {
-    abTarget: (row) => (row.abTarget && row.targetSpecies) ? `${row.abTarget} ${row.targetSpecies.join(", ")}` : row.abTarget,
-    species: (row) => `${row.targetSpecies.join(", ")}`,
-  };
-  const mapField = () => {
-    if (cellMapper[props.field]) {
-      return cellMapper[props.field](props.row)
-    }
-    return props.value ?? '';
-  }
-
   return (
     <Typography
       variant="caption"
@@ -144,7 +133,9 @@ const RenderCellContent = (props: GridRenderCellParams<String>) => {
       component="div"
       className="col-content"
     >
-      {mapField()}
+      {props.field === "targetAntigen"
+        ? `${props.row.abTarget} ${props.row.targetSpecies.join(", ")}`
+        : props.value}
     </Typography>
   );
 };
@@ -564,6 +555,8 @@ const AntibodiesTable = (props) => {
       field: "url",
       headerName: "Product URL",
       hide: true,
+      sortable: false,
+      filterable: false,
     },
     {
       ...columnsDefaultProps,

--- a/applications/portal/frontend/src/services/AntibodiesService.ts
+++ b/applications/portal/frontend/src/services/AntibodiesService.ts
@@ -25,7 +25,7 @@ export async function getAntibodies(
 }
 
 function mapAntibody(antibody: Antibody): Antibody {
-  if((!antibody.showLink || !antibody.url) && antibody.vendorUrl) {
+  if ((!antibody.url) && antibody.vendorUrl) {
     antibody.url = antibody.vendorUrl[0];
   }
   if (antibody.url && !antibody.url.includes("//")) {

--- a/applications/portal/frontend/src/utils/antibody.ts
+++ b/applications/portal/frontend/src/utils/antibody.ts
@@ -69,10 +69,10 @@ export function mapColumnToBackendModel(columnItems, modeltype) {
     "catalogNum": "catalog_num",
     "comments": "comments",
     "accession": "accession",
-    "species": "species",
+    "targetSpecies": "species",
     "applications": "applications",
     "clonality": "clonality",
-    "vendor": "vendor",
+    "vendorName": "vendor",
 
   }
   const newFilters = columnItems.map((filter) => {


### PR DESCRIPTION
Jira Link - https://metacell.atlassian.net/browse/AREG-116
```
Rule -Get antibody URL only if permitted. RULES:
1. If user is creator of the antibody, return the URL.
2. Else return only if show_link is True.
```
- Changed this rule in mapper BE - in dto layer. So this rule applies for all the APIs. 

This would affect FE in a way that - if URL is null, it is replaced by the first vendor URL as shown below. 
![image](https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/1b255568-5f96-467d-bfb4-4525fcf6cc82)

video demo

https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/27588af9-243b-4bb7-af21-33356b609b71


<br>
<br>
<hr>
<br>
<br>


Also fixes - https://metacell.atlassian.net/browse/AREG-115
(disable the column URL for filtering and sorting)


Also fixes - https://metacell.atlassian.net/browse/AREG-110
(added old RenderCellContent - hence no issue with the download or rendering)


Also Fixes a bug - 
(when filtering by M2M relationship fields - it shows multiple objects of the same id - hence add - **distinct()** to address that.