### PR TITLE
AREG-127 Contact us email text is wrapped

### DIFF
--- a/applications/portal/frontend/src/components/Support/ContactUs.tsx
+++ b/applications/portal/frontend/src/components/Support/ContactUs.tsx
@@ -20,7 +20,7 @@ const ContactUs = () => {
       <Container maxWidth='xl' sx={styles.container} className="container-contact-us">
      
         <Typography variant="subtitle1" align="center" sx={styles.message}>
-Have any questions? Please feel free to email us at {" "}
+Have any questions? Please feel free to email us at {" "}<br />
           <Link
             target="_blank"
             href="mailto:rii-help@scicrunch.org"


### PR DESCRIPTION
Issue #AREG-127
Problem: Contact us email text is wrapped
Solution: Add line break with use of <br/> tag before email

![image](https://github.com/MetaCell/scicrunch-antibody-registry/assets/67194168/1d3865b3-cefe-4a1b-91b4-6dad7c317e3c)
