### PR TITLE
Feature/areg-125 - Duplicate message not working

### DIFF
--- a/applications/portal/backend/api/services/antibody_service.py
+++ b/applications/portal/backend/api/services/antibody_service.py
@@ -46,6 +46,9 @@ def create_antibody(body: AddAntibodyDTO, userid: str) -> AntibodyDTO:
     antibody.uid = userid
     antibody.save()
 
+    if antibody.get_duplicate():
+        raise DuplicatedAntibody(antibody_mapper.to_dto(antibody))
+
     return antibody_mapper.to_dto(antibody)
 
 
@@ -61,7 +64,12 @@ def get_antibody(antibody_id: int, status=STATUS.CURATED, filters=None) -> List[
 
 def get_antibody_by_accession(accession: int) -> List[AntibodyDTO]:
     try:
-        return antibody_mapper.to_dto(Antibody.objects.get(accession=accession).select_related("vendor", "source_organism").prefetch_related("species").prefetch_related("applications"))
+        return antibody_mapper.to_dto(
+            Antibody.objects.select_related("vendor", "source_organism")
+            .prefetch_related("species")
+            .prefetch_related("applications")
+            .get(accession=accession)
+        )
     except Antibody.DoesNotExist:
         raise
     except Antibody.MultipleObjectsReturned:

--- a/applications/portal/backend/api/tests/test_antibodies.py
+++ b/applications/portal/backend/api/tests/test_antibodies.py
@@ -118,9 +118,6 @@ class AntibodiesTestCase(TestCase):
         self.assertEqual(da.vendorId, ab.vendorId)
         self.assertEqual(da.vendorName, "My vendorname")
 
-        # synonyms = VendorSynonym.objects.filter(vendor__id=da.vendorId)
-        # self.assertEqual(len(synonyms), 1)
-
         assert VendorDomain.objects.all().count() == 2
         assert Vendor.objects.all().count() == 1
 

--- a/applications/portal/backend/api/tests/test_antibodies.py
+++ b/applications/portal/backend/api/tests/test_antibodies.py
@@ -109,10 +109,10 @@ class AntibodiesTestCase(TestCase):
         a.save()
 
         duplicated = AddAntibodyDTO(**example_ab)
-        with self.assertRaises(DuplicatedAntibody) as cm:
+        with self.assertRaises(DuplicatedAntibody) as exc:
             create_antibody(duplicated, "bbb")
 
-        da = cm.exception.antibody
+        da = exc.exception.antibody
         self.assertEqual(da.abId, ab.abId)
         self.assertEqual(da.status, Status.QUEUE)
         self.assertEqual(da.vendorId, ab.vendorId)


### PR DESCRIPTION
Jira Issue - https://metacell.atlassian.net/browse/AREG-125

- Added back - raise exception if duplicate in the service layer. 
- Tests now have exception handling to accomodate the if duplicate antibody. 




Video demo

https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/b522c3c5-cd78-4b5b-b100-bd8bb630a10b

