### PR TITLE
AREG-129 - change the column position of accession in Antibody

### DIFF
--- a/applications/portal/backend/api/admin.py
+++ b/applications/portal/backend/api/admin.py
@@ -111,7 +111,7 @@ class AntibodyAdmin(ImportExportModelAdmin):
 
     # list display settings
     list_filter = ("status",)
-    list_display = (id_with_ab, "ab_name", "submitter_name", "status", "vendor", "catalog_num", "accession", "insert_time")
+    list_display = (id_with_ab, "accession", "ab_name", "submitter_name", "status", "vendor", "catalog_num", "insert_time")
     search_fields = ("ab_id", "ab_name", "catalog_num")
 
     # Edit form settings


### PR DESCRIPTION
Jira link - https://metacell.atlassian.net/browse/AREG-129

Task description
- Add accession next to ab_id, so it's easier to compare them.

![image](https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/56198cac-165f-4b2b-b572-9fd85788c699)
