### PR TITLE
Feature/AREG-131 - Fix - "Vendor type not set correctly"

### DIFF
--- a/applications/portal/backend/api/mappers/antibody_mapper.py
+++ b/applications/portal/backend/api/mappers/antibody_mapper.py
@@ -36,6 +36,7 @@ class AntibodyMapper(IDAOMapper):
             ab = Antibody()
             ab.ab_id = 0
 
+
         if dto.abTarget:
             # antigen_symbol = dto.abTarget
             # del dto.abTarget
@@ -51,7 +52,10 @@ class AntibodyMapper(IDAOMapper):
                 log.info("Adding specie: %s", specie_name)
 
         if dto.url or dto.vendorName:
-            ab.set_vendor_from_name_url(url=dto.url, name=dto.vendorName)
+            ab.set_vendor_from_name_url(
+                url=dto.url, name=dto.vendorName, 
+                commercial_type=dto.commercialType.value if dto.commercialType else None
+            )
         else:
             raise AntibodyDataException(
                 "Either vendor url or name is mandatory", 'url/name', None)

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -441,7 +441,7 @@ class Antibody(models.Model):
             alt_url = "www." + url
         return alt_url
 
-    def check_vendor_name_or_create(self, name, base_url):
+    def check_vendor_name_or_create(self, name, base_url, commercial_type=None):
         try:
             vendor = Vendor.objects.get(name__iexact=name or base_url)
         except Vendor.MultipleObjectsReturned:
@@ -453,7 +453,9 @@ class Antibody(models.Model):
                 log.info(
                     "Creating new Vendor `%s` on domain  to `%s`", vendor_name, base_url
                 )
-                vendor = Vendor(name=vendor_name, commercial_type=self.commercial_type)
+
+                # if dto.commercialType is None then set COMMERCIAL as default
+                vendor = Vendor(name=vendor_name, commercial_type=commercial_type or CommercialType.COMMERCIAL)
                 vendor.save()
                 self.vendor = vendor
                 self.add_vendor_domain(base_url, vendor)
@@ -463,7 +465,7 @@ class Antibody(models.Model):
             self.vendor = vendor
             self.add_vendor_domain(base_url, vendor)
 
-    def set_vendor_from_name_url(self, url, name=None):
+    def set_vendor_from_name_url(self, url, name=None, commercial_type=None):
         """
         If a new antibody is submitted with some vendor name and URL
         should be treated with following rules:
@@ -489,7 +491,7 @@ class Antibody(models.Model):
 
         self.vendor = vds_total[0].vendor if len(vds_total) > 0 else None
 
-        self.check_vendor_name_or_create(name, base_url)
+        self.check_vendor_name_or_create(name, base_url, commercial_type)
         if len(vds_total) > 1:
             log.error("Unexpectedly found multiple vendor domains for %s", base_url)
 

--- a/applications/portal/backend/api/models.py
+++ b/applications/portal/backend/api/models.py
@@ -94,7 +94,7 @@ class Vendor(models.Model):
     commercial_type = models.CharField(
         max_length=VENDOR_COMMERCIAL_TYPE_MAX_LEN,
         choices=CommercialType.choices,
-        default=CommercialType.OTHER,
+        default=CommercialType.COMMERCIAL,
         null=True,
         db_index=True,
     )


### PR DESCRIPTION
Jira link - https://metacell.atlassian.net/browse/AREG-131

Task description:
- pass antibody commercial_type from dto to set if new vendor is created. 


Before this PR: it use to set OTHER as default commercial_type for a new vendor. 


Logic for the implementation:
<img width="543" alt="image" src="https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/51887944-ff7a-4209-817c-5b911ae41596">



video demo

https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/f65cf45d-943e-4179-96f8-6d66464e2535


