### PR TITLE
Feature/areg-132 - Accession is not searched correctly

### DIFF
--- a/applications/portal/backend/api/admin.py
+++ b/applications/portal/backend/api/admin.py
@@ -105,7 +105,7 @@ antibody_fields_shown = (
     "ab_name", "ab_id", "accession", "commercial_type", "catalog_num", "cat_alt", "vendor", 
     "url","ab_target", "entrez_id", "uniprot_id", "target_species_raw", "subregion", 
     "modifications", "epitope", "source_organism", "clonality", "clone_id", "product_isotype",
-    "product_conjugate", "defining_citation", "product_form", "comments", "applications", 
+    "product_conjugate", "defining_citation", "product_form", "comments",
     "kit_contents", "feedback", "curator_comment", "disc_date", "status", "show_link",
     # also in the read-only fields
     "uid", "uid_legacy", "insert_time", "lastedit_time", "curate_time",
@@ -129,7 +129,7 @@ class AntibodyAdmin(ImportExportModelAdmin):
     # the following - maintains the order of the fields
     fields = antibody_fields_shown
 
-    inlines = [TargetSpeciesInlineAdmin, AntibodyFilesAdmin]
+    inlines = [TargetSpeciesInlineAdmin, AntibodyFilesAdmin, ApplicationsInlineAdmin]
     
     readonly_fields = (
         "submitter_name",

--- a/applications/portal/backend/api/controllers/search_controller.py
+++ b/applications/portal/backend/api/controllers/search_controller.py
@@ -1,4 +1,5 @@
 from typing import List
+from fastapi import HTTPException
 
 from api.services import search_service, antibody_service
 from openapi.models import FilterRequest, PaginatedAntibodies
@@ -10,7 +11,7 @@ def fts_antibodies(page: int = 1, size: int = 50, search: str = '') -> Paginated
         raise HTTPException(status_code=400, detail="Size must be less than 100")
     if search.startswith("AB_"):
         try:
-            a = antibody_service.get_antibody(int(search.replace("AB_", "")))
+            a = antibody_service.get_antibody(int(search.replace("AB_", "")), accession=int(search.replace("AB_", "")))
             return PaginatedAntibodies(page=int(page), totalElements=len(a), items=a)
         except Exception as e:
             return PaginatedAntibodies(page=int(page), totalElements=0, items=[])

--- a/applications/portal/backend/api/services/antibody_service.py
+++ b/applications/portal/backend/api/services/antibody_service.py
@@ -55,8 +55,8 @@ def create_antibody(body: AddAntibodyDTO, userid: str) -> AntibodyDTO:
 def get_antibody(antibody_id: int, status=STATUS.CURATED, filters=None, accession=None) -> List[AntibodyDTO]:
     try:
         antibody = Antibody.objects.filter(ab_id=antibody_id, status=status).filter(convert_filters_to_q(filters))
-        if accession:
-            antibody = antibody | Antibody.objects.filter(accession=accession, status=status).filter(convert_filters_to_q(filters))
+        if not antibody.exists() and accession:
+            antibody = Antibody.objects.filter(accession=accession, status=status).filter(convert_filters_to_q(filters))
         antibody = antibody.select_related("vendor", "source_organism").prefetch_related("species").prefetch_related("applications")
         return [antibody_mapper.to_dto(a) for a in antibody]
     except Antibody.DoesNotExist:

--- a/applications/portal/backend/api/services/antibody_service.py
+++ b/applications/portal/backend/api/services/antibody_service.py
@@ -53,8 +53,15 @@ def create_antibody(body: AddAntibodyDTO, userid: str) -> AntibodyDTO:
 
 
 def get_antibody(antibody_id: int, status=STATUS.CURATED, filters=None) -> List[AntibodyDTO]:
+    """
+    Look for an antibody by its ab_id and accession number (if ab_id is not found).
+    """
     try:
-        antibody = Antibody.objects.filter(ab_id=antibody_id, status=status).filter(
+        antibody = Antibody.objects.filter(ab_id=antibody_id, status=status)
+        if not antibody:
+            antibody = Antibody.objects.filter(accession=antibody_id, status=status)
+        
+        antibody = antibody.filter(
             convert_filters_to_q(filters)
         ).select_related("vendor", "source_organism").prefetch_related("species").prefetch_related("applications")
         return [antibody_mapper.to_dto(a) for a in antibody]

--- a/applications/portal/backend/api/services/search_service.py
+++ b/applications/portal/backend/api/services/search_service.py
@@ -23,7 +23,7 @@ def fts_and_filter_antibodies(page: int = 1, size: int = 10, search: str = '', f
     if "AB_" in search:
         if search.startswith("RRID:"):
             search = search.replace("RRID:", "").strip()
-        antibodies = antibody_service.get_antibody(strip_ab_from_id(search), filters=filters)
+        antibodies = antibody_service.get_antibody(strip_ab_from_id(search), filters=filters, accession=strip_ab_from_id(search))
         if antibodies:
             return PaginatedAntibodies(page=int(page), totalElements=len(antibodies), items=antibodies)
         

--- a/applications/portal/backend/api/tests/test_antibodies.py
+++ b/applications/portal/backend/api/tests/test_antibodies.py
@@ -185,6 +185,17 @@ class AntibodiesTestCase(TestCase):
         assert len(fts_antibodies(search="Rabbit").items) == 1, "case insensitive search"
         assert len(fts_antibodies(search="Andrew Dingwall").items) == 1
 
+        # Should also search for accession when searching with AB_
+        ab2 = Antibody.objects.create(
+            ab_id="1234567",
+            accession="12345689",
+            ab_name="ab2",
+        )
+        ab2.status = STATUS.CURATED
+        ab2.save()
+        assert len(fts_antibodies(search="AB_1234567").items) == 1
+        assert len(fts_antibodies(search="AB_12345689").items) == 1   ## search into accession
+
     def test_update(self):
         user_id = "aaaa"
         new_name = "My updated abName"


### PR DESCRIPTION
Closes [AREG-132](https://metacell.atlassian.net/browse/AREG-132)

# Implemented solution
- Include accession with AB_ search
 

# How to test this PR
- check the video 


...

# Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] In this PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] The relevant components are indicated in the issue (if any)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one Sprint
- [x] All the linked issues are in the Review state
- [x] All the linked issues are assigned

# Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [x] Explanatory video/animated gif




video demo 

https://github.com/MetaCell/scicrunch-antibody-registry/assets/59233227/503b6d99-982f-4999-b5e0-75c047cf5a08





[AREG-132]: https://metacell.atlassian.net/browse/AREG-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ