### PR TITLE
Feature/areg-106-fix-fts-catalog - fix N+1 query for fts by catalog number  

### DIFF
--- a/applications/portal/backend/api/repositories/search_repository.py
+++ b/applications/portal/backend/api/repositories/search_repository.py
@@ -48,7 +48,7 @@ def fts_by_catalog_number(search: str, page, size, filters=None):
             search=vector,
             ranking=SearchRank(vector, search_query, normalization=Value(1)))
         .filter(search=search_query, status=STATUS.CURATED, ranking__gte=MIN_CATALOG_RANKING)
-    )
+    ).select_related("vendor").prefetch_related("species").prefetch_related("applications")
 
     # if we match catalog_num or cat_alt, we return those results without looking for other fields
     # as the match is a perfect match or a prefix match depending on the search word,


### PR DESCRIPTION

This PR: 
- adds `select_related` and `prefetch_related` to the fts_by_catalog_number
- tests (fail still fail due to duplicate migration file) - which is fixed here - https://github.com/MetaCell/scicrunch-antibody-registry/pull/233
