### PR TITLE
Feature/areg-fts-sorting-fix - 

### DIFF
--- a/applications/portal/backend/api/repositories/search_repository.py
+++ b/applications/portal/backend/api/repositories/search_repository.py
@@ -102,7 +102,10 @@ def apply_fts_sorting(filtered_antibodies: QuerySet, filters):
     explicit_order_by = order_by_string(filters)
     if explicit_order_by:
         return filtered_antibodies.order_by(*explicit_order_by)
-    return filtered_antibodies.annotate(sorting=F("ranking") - F("antibodysearch__defining_citation") / 1000 - F("antibodysearch__disc") * 100).order_by('-sorting')
+    return filtered_antibodies.annotate(
+        ix_float=Cast("ix", FloatField()),
+        sorting=F("ranking") - F("antibodysearch__defining_citation") / 1000 - F("antibodysearch__disc") * 100 +  F("ix_float") / 1000000
+    ).order_by('-sorting')
 
 def apply_plain_sorting(filtered_antibodies: QuerySet, filters):
     """


### PR DESCRIPTION
Task description:
Problem - there are some antibodies that do not appear in the unsorted results but appear in the sorted results.
Reason - this happens due to - sorting annotation being the same for different antibodies. This leads to improper sorting and leads to inconsistent results for each page. 

Solution - add another _F("ix")_ to include as part of sorting. We do so by replacing it with the following:
```
filtered_antibodies.annotate(
        ix_float=Cast("ix", FloatField()),
        sorting=F("ranking") - F("antibodysearch__defining_citation") / 1000 - F("antibodysearch__disc") * 100 +  F("ix_float") / 1000000
    ).order_by('-sorting')

```

