### PR TITLE
Feature/areg-148 - Filters should not be persisted between my submissions and all antibodies

### DIFF
--- a/applications/portal/backend/api/repositories/filter_repository.py
+++ b/applications/portal/backend/api/repositories/filter_repository.py
@@ -12,7 +12,7 @@ def plain_filter_antibodies(page: int = 1, size: int = 10, filters=None):
     antibodies_count = filtered_antibodies.count()
 
     if antibodies_count == 0:
-        return []
+        return [], antibodies_count
 
     if antibodies_count < MAX_SORTED:
         filtered_antibodies = apply_plain_sorting(

--- a/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
+++ b/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
@@ -402,11 +402,12 @@ const AntibodiesTable = (props) => {
     getAntibodyList,
     filterModel,
     setFilterModel,
+    sortModel,
     setSortModel,
   } =
     useContext(SearchContext);
 
-  const applyFilters = (filtermodel, query) => {
+  const applyFilters = (filtermodel, query, sortmodel = sortModel) => {
     // Also does the applyFilters from the CustomFilterPanel - when apply button is clicked
     const searchmode = (props.activeTab === MYSUBMISSIONS) ? SEARCH_MODES.MY_FILTERED_AND_SEARCHED_ANTIBODIES :
       SEARCH_MODES.ALL_FILTERED_AND_SEARCHED_ANTIBODIES
@@ -414,9 +415,11 @@ const AntibodiesTable = (props) => {
       searchmode,
       query,
       1,
-      filtermodel
+      filtermodel,
+      sortmodel
     )
     filtermodel !== filterModel ? setFilterModel(filtermodel) : null;
+    sortmodel !== sortModel ? setSortModel(sortmodel) : null;
   }
 
   const addSortingColumn = (sortmodel) => {
@@ -447,7 +450,7 @@ const AntibodiesTable = (props) => {
     const isSearchInMySubmission = (props.activeTab === MYSUBMISSIONS && activeSearch)
     // NOTE: LOGIC below - if no filters exist or search query exists in my submission - don't proceed, 
     // since this is handled in separate useEffect
-    if (filterModel.items.length > 0 || isSearchInMySubmission) {
+    if (filterModel.items.length > 0 || sortModel.length > 0 || isSearchInMySubmission) {
       return;
     }
 
@@ -479,12 +482,13 @@ const AntibodiesTable = (props) => {
     // if filters exist in All Results - apply with search query
     // if no filters exist in My Submission - get My Submissions
     // if no filters exist in All Results - this case is handled in the first useEffect 
-    if (filterModel.items.length > 0) {
+    if (filterModel.items.length > 0 || sortModel.length > 0) {
       if (props.activeTab === MYSUBMISSIONS) {
-        applyFilters({ items: [] }, '')
+        applyFilters({ items: [] }, '', [])
       } else {
-        applyFilters({ items: [] }, searchQuery || activeSearch)
+        applyFilters({ items: [] }, searchQuery || activeSearch, [])
       }
+
     } else {
       if (props.activeTab === MYSUBMISSIONS) {
         getAntibodyList(SEARCH_MODES.MY_ANTIBODIES)
@@ -709,6 +713,7 @@ const AntibodiesTable = (props) => {
             pagination={true}
             paginationMode="server"
             sortingMode="server"
+              sortModel={sortModel}
             onSortModelChange={(model) => addSortingColumn(model)}
             checkboxSelection
             disableRowSelectionOnClick

--- a/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
+++ b/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
@@ -481,9 +481,9 @@ const AntibodiesTable = (props) => {
     // if no filters exist in All Results - this case is handled in the first useEffect 
     if (filterModel.items.length > 0) {
       if (props.activeTab === MYSUBMISSIONS) {
-        applyFilters(filterModel, '')
+        applyFilters({ items: [] }, '')
       } else {
-        applyFilters(filterModel, searchQuery || activeSearch)
+        applyFilters({ items: [] }, searchQuery || activeSearch)
       }
     } else {
       if (props.activeTab === MYSUBMISSIONS) {

--- a/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
+++ b/applications/portal/frontend/src/components/Home/AntibodiesTable.tsx
@@ -407,8 +407,8 @@ const AntibodiesTable = (props) => {
   } =
     useContext(SearchContext);
 
-  const applyFilters = (filtermodel, query, sortmodel = sortModel) => {
-    // Also does the applyFilters from the CustomFilterPanel - when apply button is clicked
+  const applyFilterAndSortModels = (filtermodel, query, sortmodel = sortModel) => {
+    // Also does the applyFilterAndSortModels from the CustomFilterPanel - when apply button is clicked
     const searchmode = (props.activeTab === MYSUBMISSIONS) ? SEARCH_MODES.MY_FILTERED_AND_SEARCHED_ANTIBODIES :
       SEARCH_MODES.ALL_FILTERED_AND_SEARCHED_ANTIBODIES
     getAntibodyList(
@@ -448,7 +448,7 @@ const AntibodiesTable = (props) => {
 
   useEffect(() => {
     const isSearchInMySubmission = (props.activeTab === MYSUBMISSIONS && activeSearch)
-    // NOTE: LOGIC below - if no filters exist or search query exists in my submission - don't proceed, 
+    // NOTE: LOGIC below - if no filters/sortmodel exist or search query exists in my submission - don't proceed, 
     // since this is handled in separate useEffect
     if (filterModel.items.length > 0 || sortModel.length > 0 || isSearchInMySubmission) {
       return;
@@ -469,24 +469,24 @@ const AntibodiesTable = (props) => {
     // if filters exist in All Results - apply with search query
     if (activeSearch && filterModel.items.length > 0) {
       if (props.activeTab === MYSUBMISSIONS) {
-        applyFilters(filterModel, '')
+        applyFilterAndSortModels(filterModel, '')
       } else {
-        applyFilters(filterModel, searchQuery || activeSearch)
+        applyFilterAndSortModels(filterModel, searchQuery || activeSearch)
       }
     }
   }, [activeSearch]);
 
   useEffect(() => {
     // NOTE: LOGIC below - whenever tab is changed
-    // if filters exist in My Submission - apply with empty search
-    // if filters exist in All Results - apply with search query
-    // if no filters exist in My Submission - get My Submissions
-    // if no filters exist in All Results - this case is handled in the first useEffect 
+    // if filters/sortmodel exist in My Submission - apply with empty search and empty filters/sortmodel
+    // if filters/sortmodel exist in All Results - apply with search query but empty filters/sortmodel
+    // if no filters/sortmodel exist in My Submission - get My Submissions
+    // if no filters/sortmodel exist in All Results - this case is handled in the first useEffect 
     if (filterModel.items.length > 0 || sortModel.length > 0) {
       if (props.activeTab === MYSUBMISSIONS) {
-        applyFilters({ items: [] }, '', [])
+        applyFilterAndSortModels({ items: [] }, '', [])
       } else {
-        applyFilters({ items: [] }, searchQuery || activeSearch, [])
+        applyFilterAndSortModels({ items: [] }, searchQuery || activeSearch, [])
       }
 
     } else {
@@ -713,7 +713,7 @@ const AntibodiesTable = (props) => {
             pagination={true}
             paginationMode="server"
             sortingMode="server"
-              sortModel={sortModel}
+            sortModel={sortModel}
             onSortModelChange={(model) => addSortingColumn(model)}
             checkboxSelection
             disableRowSelectionOnClick
@@ -737,7 +737,7 @@ const AntibodiesTable = (props) => {
               filterPanel: () => CustomFilterPanel({
                 columns,
                 filterModel,
-                applyFilters,
+                applyFilterAndSortModels,
                 setFilterModel,
               }),
             }}

--- a/applications/portal/frontend/src/components/Home/CustomFilterPanel.tsx
+++ b/applications/portal/frontend/src/components/Home/CustomFilterPanel.tsx
@@ -16,7 +16,7 @@ export const CustomFilterPanel = (
     columns,
     filterModel,
     setFilterModel,
-    applyFilters,
+    applyFilterAndSortModels,
   }) => {
 
   const { activeSearch } = useContext(searchContext);
@@ -93,7 +93,7 @@ export const CustomFilterPanel = (
           variant="outlined"
           color="primary"
           onClick={() => {
-            applyFilters(filterModel, activeSearch);
+            applyFilterAndSortModels(filterModel, activeSearch);
           }}
           sx={{ m: 1 }}
         >

--- a/applications/portal/frontend/src/components/NavBar/Searchbar.tsx
+++ b/applications/portal/frontend/src/components/NavBar/Searchbar.tsx
@@ -48,7 +48,9 @@ export default function Searchbar(props) {
     loader,
     activeSearch,
     filterModel,
+    setFilterModel,
     sortModel,
+    setSortModel,
     setActiveSearch
   } = useContext(SearchContext)
 
@@ -70,6 +72,8 @@ export default function Searchbar(props) {
     } else {
       if (props.activeTab === MYSUBMISSIONS) {
         setActiveSearch(e.target.value)
+        setFilterModel({ items: [] })
+        setSortModel([])
         history.push('')
       } else {
         isFilterAndSortModelEmpty(filterModel, sortModel) ?


### PR DESCRIPTION
Closes [AREG-148](https://metacell.atlassian.net/browse/AREG-148)

# Implemented solution

NOTE: also updated BE - fixed the return value for [plain_filter_antibodies](https://github.com/MetaCell/scicrunch-antibody-registry/pull/266/commits/3f1ba55f16ea9d161668b2b055e38a0aea798595)


Changes two behaviors:

1. when we change the tab - from "All Results" to "My Submission" and vice versa. The new changes will - reset the filters and sort models. 
2. when we search for something in the "My Submission" tab. We were thrown back to the All Results, we continued this behavior but after the new changes - we removed the filters and sort model (in case we had them - since the tab was changed).


This PR also updates the necessary comments and function renaming. 

Short video demo:

https://github.com/user-attachments/assets/2a4c91e7-53b3-442e-b414-2e9405a47083


...

# Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] In this PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] The relevant components are indicated in the issue (if any)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one Sprint
- [ ] All the linked issues are in the Review state
- [ ] All the linked issues are assigned

# Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change` and the migration procedure is well described [above](#implemented-solution)

# Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [x] Explanatory video/animated gif


[AREG-148]: https://metacell.atlassian.net/browse/AREG-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ